### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,18 @@
 language: crystal
-addons:
-  apt:
-    packages:
-    - librocksdb-dev
+sudo: true
 script:
   - make test
+
+before_install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo apt-get update -qq
+  - sudo apt-get install gcc g++ libsnappy-dev zlib1g-dev libbz2-dev -qq
+
+install:
+  - git clone https://github.com/facebook/rocksdb.git /tmp/rocksdb
+  - pushd /tmp/rocksdb
+  - make clean
+  - make shared_lib
+  - sudo make install-shared
+  - sudo ln -s /usr/local/lib/librocksdb* /usr/lib
+  - popd


### PR DESCRIPTION
This is a way to have Travis CI used with your RocksDB project. I already used that for our fork of [similar lib for Ruby](https://github.com/Boostcom/rocksdb-ruby) and I just ported it here with some testing.

What it does is building RocksDB from scratch so it take a lot of time (15 - 20 minutes), but I guess it's better than nothing.

Here is example of Travis job: https://travis-ci.org/katafrakt/rocksdb.cr/builds/389723637